### PR TITLE
Add reg-pull-many-sub {:type :pull-many :ids [...]}

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Another example to show usage of `pull-many` from a query that returns several e
    :ids      (reduce into [] entity-ids)}))
 ```
 
-Note the `(reduce ...)` & recall that the query returns its results in form `#{[1] [2] ...}`, but the pull-many sub expects a vector of entity-ids.
+Note the `(reduce ...)` & recall that the query returns its results in form `#{[1] [2] ...}`, but the pull-many sub expects a sequence of entity-ids.
 
  ## Events
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Pull subscriptions creates subscription to the entity. `reg-pull-sub` function c
 
 Pull-many subscriptions are similar to pull but take a vector of entity-ids.
 
-```
+```clojure
 (reg-pull-many-sub
    :sub-name
    '[*])

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can also leverage [DatSync](https://github.com/metasoarous/datsync) to have 
 re-frame is a [reactive programming](https://gist.github.com/staltz/868e7e9bc2a7b8c1f754) library for writing single-page apps in ClojureScript
  using [Reagent](https://github.com/reagent-project/reagent), which wraps Facebook's popular [React](https://facebook.github.io/react/) library for building component-oriented user interfaces.
 
-[Posh](https://github.com/mpdairy/posh) improves Reagent to allow the declarative binding of user interface components to a local DataScript database. Like Datomic, DataScript supports the powerful `q` and `pull` query API's, and [Datalog](http://www.learndatalogtoday.org/) in general.
+[Posh](https://github.com/denistakeda/posh) improves Reagent to allow the declarative binding of user interface components to a local DataScript database. Like Datomic, DataScript supports the powerful `q` and `pull` query API's, and [Datalog](http://www.learndatalogtoday.org/) in general.
 
 `re-posh` allows Posh and re-frame to work together by adding support for re-frame specific `subscriptions`, `events`, `effects`, and `co-effects` to Posh.
 
@@ -85,7 +85,7 @@ reg-sub needs three things:
  - the required inputs for this node
  - a function that generates config for query or pull for this node
 
-The `query-id` is always the 1st argument to reg-sub and it is typicallya namespaced keyword.
+The `query-id` is always the 1st argument to reg-sub and it is typically a namespaced keyword.
 
 A config function is always the last argument and it has this general form: `(input-signals, query-vector) -> a-value`
 
@@ -198,6 +198,19 @@ Pull subscriptions creates subscription to the entity. `reg-pull-sub` function c
        entity    (subscribe [:sub-name entity-id])])
 ```
 
+Pull-many subscriptions are similar to pull but take a vector of entity-ids.
+
+```
+(reg-pull-many-sub
+   :sub-name
+   '[*])
+
+ ;; Usage
+
+ (let [entity-id 123
+       entity    (subscribe [:sub-name [eids])])
+```
+
 ### Combining subscriptions
 
 It's often the case that combining of several subscriptions (espetially query and pull subscriptions) required. Unfortunatelly `re-posh` doesn't support combining them inside query. But there is another way. The classical example is when we have a query that returns some object id and we needs the whole object (pull). Here is how can we do that:
@@ -220,6 +233,27 @@ It's often the case that combining of several subscriptions (espetially query an
 ```
 
 In this example two queries are generated. The first one is independent. It returns the id of required object. The second one depends of the first one. It takes the object id as param and returns the whole object.
+
+Another example to show usage of `pull-many` from a query that returns several entity-ids.
+
+```clojure
+(reg-sub
+ :todo-ids
+ (fn [_ _]
+  {:type  :query
+   :query '[:find ?id
+            :where [?id :item/type :type/todo]}))
+
+(reg-sub
+ :todos
+ :<- [:todo-ids]
+ (fn [entity-ids _]
+  {:type    :pull-many
+   :pattern '[*]
+   :ids      (reduce into [] entity-ids)}))
+```
+
+Note the `(reduce ...)` & recall that the query returns its results in form `#{[1] [2] ...}`, but the pull-many sub expects a vector of entity-ids.
 
  ## Events
 
@@ -276,6 +310,6 @@ Pull requests are welcome. Email me on <denis.takeda@gmail.com> if you have any 
 
  ## License
 
- Copyright © 2018 Denis Krivosheev
+ Copyright © 2019 Denis Krivosheev
 
  Distributed under the MIT License

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject re-posh "0.3.1-SNAPSHOT"
+(defproject re-posh "0.3.1"
   :description "Use your re-frame with DataScript as a data storage"
   :url "https://github.com/denistakeda/re-posh"
   :license {:name "MIT"
@@ -6,6 +6,4 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [datascript "0.18.7"]
                  [re-frame "0.10.7"]
-                 ;; NOTE: @denistakeda using my private fork, but now that you have Posh ownership
-                 ;;       release Posh with pull-many support & update below dependency
-                 [org.clojars.questyarbrough/posh "0.5.8-SNAPSHOT"]])
+                 [denistakeda/posh "0.5.7"]])

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,11 @@
-(defproject re-posh "0.3.0"
+(defproject re-posh "0.3.1-SNAPSHOT"
   :description "Use your re-frame with DataScript as a data storage"
   :url "https://github.com/denistakeda/re-posh"
   :license {:name "MIT"
             :url "https://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [datascript "0.16.6"]
-                 [re-frame "0.10.5"]
-                 [posh "0.5.5"]])
+                 [datascript "0.18.7"]
+                 [re-frame "0.10.7"]
+                 ;; NOTE: @denistakeda using my private fork, but now that you have Posh ownership
+                 ;;       release Posh with pull-many support & update below dependency
+                 [org.clojars.questyarbrough/posh "0.5.8-SNAPSHOT"]])

--- a/src/re_posh/core.cljc
+++ b/src/re_posh/core.cljc
@@ -9,6 +9,7 @@
 
 (def reg-query-sub subs/reg-query-sub)
 (def reg-pull-sub subs/reg-pull-sub)
+(def reg-pull-many-sub subs/reg-pull-many-sub)
 (def reg-sub subs/reg-sub)
 (def reg-event-ds events/reg-event-ds)
 (def connect! db/connect!)

--- a/src/re_posh/subs.cljc
+++ b/src/re_posh/subs.cljc
@@ -190,7 +190,17 @@
 
 (defn reg-pull-many-sub
   "Syntax sugar for writing pull-many queries.
-  Same as reg-pull-sub but takes vector of eids under key :ids"
+  Same as reg-pull-sub but takes vector of eids under key :ids
+
+  (reg-pull-many-sub
+   :things
+   '[*])
+
+  It's possible to subscribe to this pull-many query with
+
+  (re-posh/subscribe [:things ids])
+
+  Where ids is a sequence of entity ids"
   [sub-name pattern]
   (reg-sub
    sub-name

--- a/src/re_posh/subs.cljc
+++ b/src/re_posh/subs.cljc
@@ -17,6 +17,10 @@
   [{:keys [pattern id]}]
   (p/pull @store pattern id))
 
+(defmethod execute-sub :pull-many
+  [{:keys [pattern ids]}]
+  (p/pull-many @store pattern ids))
+
 (defn reg-sub
   "For a given `query-id` register a `config` function and input `signals`
 
@@ -183,3 +187,14 @@
      {:type    :pull
       :pattern pattern
       :id      id})))
+
+(defn reg-pull-many-sub
+  "Syntax sugar for writing pull-many queries.
+  Same as reg-pull-sub but takes vector of eids under key :ids"
+  [sub-name pattern]
+  (reg-sub
+   sub-name
+   (fn [_ [_ ids]]
+     {:type    :pull-many
+      :pattern pattern
+      :ids     ids})))


### PR DESCRIPTION
Adds support for `pull-many` along with a section in the README.md.

An example `reg-sub` is included below.

```
(re-posh/reg-sub
 :todos
 :<- [:todo-eids]
 (fn [eids _]
   {:type :pull-many
    :pattern '[*]
    :ids (reduce into [] eids)}))
```

This is working on my local re-frame project, and I have published this functionality under `[org.clojars.questyarbrough/re-posh "0.3.1-SNAPSHOT"]` for interim usage.

@denistakeda Note that this is using my snapshot dependency of `posh` in project.clj -- since you are now the maintainer of Posh (& thank you for that), please release a version of Posh that contains `pull-many` support from https://github.com/mpdairy/posh/pull/39 , then update the project.clj here before releasing re-posh.

Fixes https://github.com/denistakeda/re-posh/issues/26